### PR TITLE
Add modern web calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Projekt01
+
+Dieses Repository enthält einen einfachen webbasierten Taschenrechner mit modernem Design.  
+Die Anwendung befindet sich im Ordner `calculator`.
+
+## Verwendung
+
+1. Einen lokalen Webserver starten (z. B. mit [VS Code Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) oder `python3 -m http.server`).
+2. Die `index.html` im Browser öffnen.
+
+Der Rechner unterstützt die Grundrechenarten und bietet eine einfache Bedienoberfläche.

--- a/calculator/index.html
+++ b/calculator/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Moderner Rechner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="calculator">
+        <input type="text" class="display" id="display" disabled>
+        <div class="keys">
+            <button class="key" data-action="clear">C</button>
+            <button class="key" data-action="delete">⌫</button>
+            <button class="key" data-value="/">÷</button>
+            <button class="key" data-value="*">×</button>
+
+            <button class="key" data-value="7">7</button>
+            <button class="key" data-value="8">8</button>
+            <button class="key" data-value="9">9</button>
+            <button class="key" data-value="-">−</button>
+
+            <button class="key" data-value="4">4</button>
+            <button class="key" data-value="5">5</button>
+            <button class="key" data-value="6">6</button>
+            <button class="key" data-value="+">+</button>
+
+            <button class="key" data-value="1">1</button>
+            <button class="key" data-value="2">2</button>
+            <button class="key" data-value="3">3</button>
+            <button class="key" data-action="calculate" rowspan="2" class="equal">=</button>
+
+            <button class="key zero" data-value="0">0</button>
+            <button class="key" data-value=".">.</button>
+        </div>
+    </div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/calculator/script.js
+++ b/calculator/script.js
@@ -1,0 +1,31 @@
+(function() {
+    const display = document.getElementById('display');
+    const keys = document.querySelector('.keys');
+
+    keys.addEventListener('click', function(e) {
+        const target = e.target;
+        if (!target.classList.contains('key')) return;
+
+        const value = target.dataset.value;
+        const action = target.dataset.action;
+
+        if (action === 'clear') {
+            display.value = '';
+            return;
+        }
+        if (action === 'delete') {
+            display.value = display.value.slice(0, -1);
+            return;
+        }
+        if (action === 'calculate') {
+            try {
+                display.value = eval(display.value) || '';
+            } catch {
+                display.value = 'Error';
+            }
+            return;
+        }
+
+        display.value += value;
+    });
+})();

--- a/calculator/style.css
+++ b/calculator/style.css
@@ -1,0 +1,59 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f2f2f2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.calculator {
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    width: 320px;
+    padding: 20px;
+}
+
+.display {
+    width: 100%;
+    height: 50px;
+    font-size: 1.4rem;
+    text-align: right;
+    padding: 10px;
+    border: none;
+    background: #e8e8e8;
+    margin-bottom: 20px;
+    border-radius: 5px;
+}
+
+.keys {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+}
+
+.key {
+    padding: 15px;
+    font-size: 1.2rem;
+    border: none;
+    border-radius: 5px;
+    background: #f1f1f1;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.key:hover {
+    background: #ddd;
+}
+
+.key[data-action="calculate"] {
+    grid-column: span 1;
+    background: #0078d7;
+    color: #fff;
+}
+
+.key.zero {
+    grid-column: span 2;
+}


### PR DESCRIPTION
## Summary
- add a simple web-based calculator with HTML/CSS/JS
- document how to run it in the README

## Testing
- `node -e "require('fs').readFileSync('calculator/script.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_6861b1876858832699831675ac0d4270